### PR TITLE
Added the support for stop action

### DIFF
--- a/python_wrapper/susi_python/main.py
+++ b/python_wrapper/susi_python/main.py
@@ -91,6 +91,8 @@ def generate_result(response):
             entities = get_rss_entities(data)
             count = action.count
             result['rss'] = {'entities': entities, 'count': count}
+        elif isinstance(action, StopAction):
+            break
 
     return result
 

--- a/python_wrapper/susi_python/models.py
+++ b/python_wrapper/susi_python/models.py
@@ -123,6 +123,9 @@ class RssAction(BaseAction):
         self.description = description
         self.link = link
 
+class StopAction(BaseAction):
+    def __init__(self):
+        super().__init__()
 
 class Session:
     def __init__(self, identity):

--- a/python_wrapper/susi_python/response_parser.py
+++ b/python_wrapper/susi_python/response_parser.py
@@ -14,6 +14,8 @@ def get_action(jsn):
         return RssAction(jsn['count'], jsn['title'], jsn['description'], jsn['link'])
     elif jsn['type'] == 'video_play':
         return VideoAction(jsn['identifier'], jsn['identifier_type'])
+    elif jsn['type'] == 'stop':
+        return StopAction()
     else:
         return UnknownAction()
 


### PR DESCRIPTION
I have added support for stop action. 

In the below example, I have forcefully created an invalid query by pressing `ctrl + r`.
And then used the `stop` action to kill the process.

![test](https://user-images.githubusercontent.com/29942790/40590032-cc48fb74-6215-11e8-957b-fd8e375b3ad0.gif)
 